### PR TITLE
Prevent RejectedExecutionException in async mode

### DIFF
--- a/materialshadows/src/main/java/com/sdsmdg/harjot/materialshadows/MaterialShadowFrameLayoutWrapper.java
+++ b/materialshadows/src/main/java/com/sdsmdg/harjot/materialshadows/MaterialShadowFrameLayoutWrapper.java
@@ -82,6 +82,7 @@ public class MaterialShadowFrameLayoutWrapper extends FrameLayout {
         super.onDetachedFromWindow();
         if (shadowGenerator != null) {
             shadowGenerator.releaseResources();
+            shadowGenerator = null;
         }
     }
 

--- a/materialshadows/src/main/java/com/sdsmdg/harjot/materialshadows/MaterialShadowViewWrapper.java
+++ b/materialshadows/src/main/java/com/sdsmdg/harjot/materialshadows/MaterialShadowViewWrapper.java
@@ -96,6 +96,7 @@ public class MaterialShadowViewWrapper extends RelativeLayout {
         super.onDetachedFromWindow();
         if (shadowGenerator != null) {
             shadowGenerator.releaseResources();
+            shadowGenerator = null;
         }
     }
 


### PR DESCRIPTION
Thanks for this excellent library!  I've noticed on some devices that use of the back button results in a RejectedExceutionException.  It appears that the onDetachedFromWindow method is invoked which releases resources for the underlying shadowGenerator.  The shadowGenerator shuts down its thread pool.  If this wrapper is reused afterwards in async mode, a crash occurs when tasks are submitted to this thread pool.  A simple fix seems to be simply nulling out this underlying shadowGenerator so that a new one will be constructed if needed.